### PR TITLE
Tie to latest compatible react commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "license" : "GPL-3.0+",
     "require" : {
         "php" : ">=5.5",
-        "react/http" : "dev-master",
+        "react/http" : "dev-master#cd15204bd15d106d7832c680e4fb0ca0ce2f5e30",
         "mcustiel/php-simple-request" : "^3.1",
         "symfony/cache": "^3.1",
         "mcustiel/power-route" : "^2.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d0d0789a7d32de81ad118e0c4e9223fa",
-    "content-hash": "e09c284a25529d3925572fae68dd1d11",
+    "hash": "da4e9bae4a169b7e47eb3c6500fff785",
+    "content-hash": "4afa044653f909f62ba8ce29bd776ea7",
     "packages": [
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
Ties react/http to a particular commit as they just backed out a load of code that phiremock relies on (https://github.com/reactphp/http/pull/59)
