### PR TITLE
Allow for different php interpreter locations

### DIFF
--- a/bin/phiremock
+++ b/bin/phiremock
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 declare(ticks = 1);
 


### PR DESCRIPTION
Hi there, thank you for such a useful piece of software. I wanted to suggest you add this change simply to allow for different install locations for the php interpreter. This is quite common for mac users who user [Homebrew](http://brew.sh) as a package manager.