### PR TITLE
Native JSON support in request body

### DIFF
--- a/src/Domain/Response.php
+++ b/src/Domain/Response.php
@@ -18,6 +18,7 @@ class Response implements \JsonSerializable
      */
     private $statusCode = 200;
     /**
+     * @SRF\CustomFilter(class="\Mcustiel\Phiremock\Server\Http\ResponseFilters\JsonToString")
      * @SRV\OneOf({
      *      @SRV\Type("string"),
      *      @SRV\Not(@SRV\NotNull)

--- a/src/Server/Http/ResponseFilters/JsonToString.php
+++ b/src/Server/Http/ResponseFilters/JsonToString.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mcustiel\Phiremock\Server\Http\ResponseFilters;
+
+use Mcustiel\SimpleRequest\Interfaces\FilterInterface;
+
+class JsonToString implements FilterInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @see \Mcustiel\SimpleRequest\Interfaces\Specificable::setSpecification()
+     */
+    public function setSpecification($specification = null)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see \Mcustiel\SimpleRequest\Interfaces\FilterInterface::filter()
+     */
+    public function filter($value)
+    {
+        return is_array($value) || is_object($value) ? json_encode($value) : $value;
+    }
+}
+

--- a/tests/tests/acceptance/BodyJsonCest.php
+++ b/tests/tests/acceptance/BodyJsonCest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Mcustiel\Phiremock\Domain\Condition;
+use Mcustiel\Phiremock\Domain\Expectation;
+use Mcustiel\Phiremock\Domain\Request;
+use Mcustiel\Phiremock\Domain\Response;
+
+class BodyJsonCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+        $I->sendDELETE('/__phiremock/expectations');
+    }
+
+    public function createExpectationWithBodyJsonArrayTest(AcceptanceTester $I)
+    {
+        $I->wantTo('create an expectation with a JSON body defined as array');
+        $request = new Request();
+        $request->setUrl(new Condition('isEqualTo', '/the/request/url'));
+        $response = new Response();
+        $response->setBody(array('foo' => 'bar'));
+        $expectation = new Expectation();
+        $expectation->setRequest($request)->setResponse($response);
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPOST('/__phiremock/expectations', $expectation);
+        $I->seeResponseCodeIs('201');
+
+        $I->sendGET('/__phiremock/expectations');
+        $I->seeResponseCodeIs('200');
+        $I->seeResponseIsJson();
+        $I->seeResponseEquals(
+            '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null},'
+            . '"response":{"statusCode":200,"body":"{\"foo\":\"bar\"}","headers":null,"delayMillis":null},'
+            . '"proxyTo":null,"priority":0}]'
+        );
+    }
+
+    public function createExpectationWithBodyJsonObjectTest(AcceptanceTester $I)
+    {
+        $I->wantTo('create an expectation with a JSON body defined as object');
+        $request = new Request();
+        $request->setUrl(new Condition('isEqualTo', '/the/request/url'));
+        $response = new Response();
+        $response->setBody((object) array('foo' => 'bar'));
+        $expectation = new Expectation();
+        $expectation->setRequest($request)->setResponse($response);
+        $I->haveHttpHeader('Content-Type', 'application/json');
+        $I->sendPOST('/__phiremock/expectations', $expectation);
+        $I->seeResponseCodeIs('201');
+
+        $I->sendGET('/__phiremock/expectations');
+        $I->seeResponseCodeIs('200');
+        $I->seeResponseIsJson();
+        $I->seeResponseEquals(
+            '[{"scenarioName":null,"scenarioStateIs":null,"newScenarioState":null,'
+            . '"request":{"method":null,"url":{"isEqualTo":"\/the\/request\/url"},"body":null,"headers":null},'
+            . '"response":{"statusCode":200,"body":"{\"foo\":\"bar\"}","headers":null,"delayMillis":null},'
+            . '"proxyTo":null,"priority":0}]'
+        );
+    }
+}


### PR DESCRIPTION
Issue link: https://github.com/mcustiel/phiremock/issues/17

Test results:
```
$ vendor/bin/codecept -c tests/ run
Codeception PHP Testing Framework v2.3.5
Powered by PHPUnit 6.2.4 by Sebastian Bergmann and contributors.
Running exec php /opt/phiremock/tests/tests/../../bin/phiremock --port 8086

Acceptance Tests (66) -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
✔ BodyConditionCest: Create an expectation that checks body using isequalto (0.04s)
✔ BodyConditionCest: Create an expectation that checks body using matches (0.01s)
✔ BodyConditionCest: See if request fails when an invalid matcher is specified (0.01s)
✔ BodyConditionCest: Check if the request fails when and invalid value is specified (0.01s)
✔ BodyConditionCest: See if mocking based in request body pattern works (0.01s)
✔ BodyConditionCest: See if mocking based in request body equality works (0.01s)
✔ BodyConditionCest: See if mocking based in request body case insensitive equality works (0.01s)
✔ BodyJsonCest: Create an expectation with a json body defined as array (0.01s)
✔ BodyJsonCest: Create an expectation with a json body defined as object (0.01s)
✔ BodySpecificationCest: Create an expectation with a valid body (0.01s)
✔ BodySpecificationCest: Create an expectation with an empty body (0.01s)
✔ ClientCest: Should create an expectation test (0.01s)
✔ ClientCest: Should create an expectation and receive it in the list (0.02s)
✔ ClientCest: Should list several expectations (0.02s)
✔ ClientCest: Should create an expectation test with fluent interface (3.52s)
✔ ClientCest: Count executions test (0.03s)
✔ ClientCest: Count executions when no expectation is set (0.03s)
✔ ClientCest: Contains matcher should work (2.51s)
✔ ClientCest: Full url should be evaluated (2.52s)
✔ DelaySpecificationCest: Create an expectation with a valid delay specification (0.01s)
✔ DelaySpecificationCest: Create an expectation with a negative delay specification (0.01s)
✔ DelaySpecificationCest: Create an expectation with an invalid delay specification (0.01s)
✔ DelaySpecificationCest: Mock a request with delay (2.01s)
✔ ExpectationCreationCest: Create an expectation that only checks url (0.01s)
✔ ExpectationCreationCest: Create an expectation that only checks method (0.01s)
✔ ExpectationCreationCest: Create an expectation that only checks body (0.01s)
✔ ExpectationCreationCest: Create an expectation that only checks headers (0.01s)
✔ ExpectationCreationCest: See if creation fails when request is empty (0.01s)
✔ ExpectationCreationCest: When response is empty in request, default should be used (0.01s)
✔ ExpectationCreationCest: See if creation fails when anything sent as request (0.01s)
✔ ExpectationCreationCest: See if creation fails when anything sent as response (0.01s)
✔ ExpectationCreationCest: Create an expectation with all possible option filled (0.01s)
✔ ExpectationListCest: Return empty list test (0.00s)
✔ ExpectationListCest: Return created expectation test (0.01s)
✔ HeadersConditionsCest: Create an expectation that checks one header using isequalto (0.01s)
✔ HeadersConditionsCest: Create an expectation that checks one header using matches (0.01s)
✔ HeadersConditionsCest: Fail when the matcher is invalid (0.01s)
✔ HeadersConditionsCest: Fail when the value is null (0.01s)
✔ HeadersConditionsCest: Create an expectation that checks more than one header (0.01s)
✔ HeadersConditionsCest: See if mocking based in one request header works (0.01s)
✔ HeadersConditionsCest: See if mocking based in several request headers works (0.01s)
✔ HeadersSpecificationCest: Create an specification with one header in response (0.01s)
✔ HeadersSpecificationCest: Create an specification with several headers in response (0.01s)
✔ HeadersSpecificationCest: Create a specification with no headers in response (0.01s)
✔ HeadersSpecificationCest: Fail when creating a specification with invalid headers (0.01s)
✔ MethodConditionCest: Create a specification with method post (0.01s)
✔ MethodConditionCest: Create a specification with method get (0.01s)
✔ MethodConditionCest: Create a specification with method put (0.01s)
✔ MethodConditionCest: Create a specification with method delete (0.01s)
✔ MethodConditionCest: Create a specification with method fetch (0.01s)
✔ MethodConditionCest: Create a specification with method options (0.01s)
✔ MethodConditionCest: Create a specification with method head (0.01s)
✔ MethodConditionCest: Create a specification with method patch (0.01s)
✔ MethodConditionCest: Create a specification that checks url using matches (0.01s)
✔ ProxyCest: Create an expectation with proxy to test (0.01s)
✔ ProxyCest: Proxy to given uri test (0.62s)
✔ ReplacementCest: Create an expectation with regex replacement from url (0.01s)
✔ ReplacementCest: Create an expectation with regex replacement from body (0.01s)
✔ ReplacementCest: Create an expectation with regex replacement from body and url (0.01s)
✔ StatusCodeSpecificationCest: Create a specification with a valid status code (0.01s)
✔ StatusCodeSpecificationCest: Create a specification with a default status code (0.01s)
✔ StatusCodeSpecificationCest: Fail when the status code is not set (0.01s)
✔ UrlConditionCest: Create an expectation that checks url using isequalto (0.01s)
✔ UrlConditionCest: Create an expectation that checks url using matches (0.01s)
✔ UrlConditionCest:  check if it fails when an invalid matcher is specified (0.01s)
✔ UrlConditionCest: Check if it fails when an invalid value is specified (0.01s)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Functional Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Unit Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Time: 13.1 seconds, Memory: 16.00MB

OK (66 tests, 244 assertions)
```
P.S. With this changes apply PSR cache should be cleared, because response parser is cached in
`\Mcustiel\SimpleRequest\RequestBuilder`:
```
    private function generateRequestParserObject($className, RequestParser $parser)
    {
        $cacheKey = str_replace('\\', '', $className . get_class($parser));
        $cacheItem = $this->cache->getItem($cacheKey);
        $return = $cacheItem->get();
        if ($return === null) {
            $return = $this->parserGenerator->populateRequestParser($className, $parser, $this);
            $cacheItem->set($return);
            $this->cache->save($cacheItem);
        }

        return $return;
    }
```
I've changed branch from master to my one and was confused as I didn't see an effect from the changes.