### PR TITLE
Issue #21: List all expectations failed with annotation not found error

### DIFF
--- a/src/Client/Phiremock.php
+++ b/src/Client/Phiremock.php
@@ -2,6 +2,7 @@
 
 namespace Mcustiel\Phiremock\Client;
 
+use Doctrine\Common\Annotations\AnnotationRegistry;
 use Mcustiel\Phiremock\Client\Utils\ExpectationBuilder;
 use Mcustiel\Phiremock\Client\Utils\RequestBuilder;
 use Mcustiel\Phiremock\Common\Http\Implementation\GuzzleConnection;
@@ -48,6 +49,8 @@ class Phiremock
         $this->host = $host;
         $this->port = $port;
         $this->connection = $remoteConnection;
+
+        $this->registerAnnotationsLoader();
     }
 
     /**
@@ -208,5 +211,16 @@ class Phiremock
         }
 
         return $this->simpleRequestBuilder;
+    }
+
+    private function registerAnnotationsLoader()
+    {
+        if (file_exists(__DIR__ . '/../../vendor/autoload.php')) {
+            $loader = require __DIR__ . '/../../vendor/autoload.php';
+        } else {
+            $loader = require __DIR__ . '/../../../../autoload.php';
+        }
+
+        AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
     }
 }

--- a/tests/tests/_bootstrap.php
+++ b/tests/tests/_bootstrap.php
@@ -1,7 +1,3 @@
 <?php
 
 define('APP_ROOT', __DIR__ . '/../../');
-
-$loader = require APP_ROOT . 'vendor/autoload.php';
-
-\Doctrine\Common\Annotations\AnnotationRegistry::registerLoader([$loader, 'loadClass']);


### PR DESCRIPTION
Issue link: https://github.com/mcustiel/phiremock/issues/21

Tests result:
```
$ vendor/bin/codecept -c tests/ run
Codeception PHP Testing Framework v2.3.5
Powered by PHPUnit 6.2.4 by Sebastian Bergmann and contributors.
Running exec php /opt/phiremock/tests/tests/../../bin/phiremock --port 8086

Acceptance Tests (68) -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
✔ BodyConditionCest: Create an expectation that checks body using isequalto (0.05s)
✔ BodyConditionCest: Create an expectation that checks body using matches (0.02s)
✔ BodyConditionCest: See if request fails when an invalid matcher is specified (0.01s)
✔ BodyConditionCest: Check if the request fails when and invalid value is specified (0.01s)
✔ BodyConditionCest: See if mocking based in request body pattern works (0.01s)
✔ BodyConditionCest: See if mocking based in request body equality works (0.01s)
✔ BodyConditionCest: See if mocking based in request body case insensitive equality works (0.01s)
✔ BodyJsonCest: Create an expectation with a json body defined as array (0.01s)
✔ BodyJsonCest: Create an expectation with a json body defined as object (0.01s)
✔ BodySpecificationCest: Create an expectation with a valid body (0.01s)
✔ BodySpecificationCest: Create an expectation with an empty body (0.01s)
✔ ClientCest: Should create an expectation test (0.01s)
✔ ClientCest: Should create an expectation and receive it in the list (0.02s)
✔ ClientCest: Should list several expectations (0.02s)
✔ ClientCest: Should create an expectation test with fluent interface (3.52s)
✔ ClientCest: Count executions test (0.03s)
✔ ClientCest: Count executions when no expectation is set (0.03s)
✔ ClientCest: Contains matcher should work (2.51s)
✔ ClientCest: Full url should be evaluated (2.52s)
✔ DelaySpecificationCest: Create an expectation with a valid delay specification (0.02s)
✔ DelaySpecificationCest: Create an expectation with a negative delay specification (0.01s)
✔ DelaySpecificationCest: Create an expectation with an invalid delay specification (0.01s)
✔ DelaySpecificationCest: Mock a request with delay (2.01s)
✔ ExpectationCreationCest: Create an expectation that only checks url (0.02s)
✔ ExpectationCreationCest: Create an expectation that only checks method (0.02s)
✔ ExpectationCreationCest: Create an expectation that only checks body (0.01s)
✔ ExpectationCreationCest: Create an expectation that only checks headers (0.01s)
✔ ExpectationCreationCest: See if creation fails when request is empty (0.01s)
✔ ExpectationCreationCest: When response is empty in request, default should be used (0.01s)
✔ ExpectationCreationCest: See if creation fails when anything sent as request (0.01s)
✔ ExpectationCreationCest: See if creation fails when anything sent as response (0.01s)
✔ ExpectationCreationCest: Create an expectation with all possible option filled (0.01s)
✔ ExpectationListCest: Return empty list test (0.00s)
✔ ExpectationListCest: Return created expectation test (0.01s)
✔ HeadersConditionsCest: Create an expectation that checks one header using isequalto (0.01s)
✔ HeadersConditionsCest: Create an expectation that checks one header using matches (0.01s)
✔ HeadersConditionsCest: Fail when the matcher is invalid (0.01s)
✔ HeadersConditionsCest: Fail when the value is null (0.01s)
✔ HeadersConditionsCest: Create an expectation that checks more than one header (0.01s)
✔ HeadersConditionsCest: See if mocking based in one request header works (0.01s)
✔ HeadersConditionsCest: See if mocking based in several request headers works (0.01s)
✔ HeadersSpecificationCest: Create an specification with one header in response (0.01s)
✔ HeadersSpecificationCest: Create an specification with several headers in response (0.01s)
✔ HeadersSpecificationCest: Create a specification with no headers in response (0.01s)
✔ HeadersSpecificationCest: Fail when creating a specification with invalid headers (0.01s)
✔ MethodConditionCest: Create a specification with method post (0.01s)
✔ MethodConditionCest: Create a specification with method get (0.01s)
✔ MethodConditionCest: Create a specification with method put (0.01s)
✔ MethodConditionCest: Create a specification with method delete (0.01s)
✔ MethodConditionCest: Create a specification with method fetch (0.01s)
✔ MethodConditionCest: Create a specification with method options (0.01s)
✔ MethodConditionCest: Create a specification with method head (0.01s)
✔ MethodConditionCest: Create a specification with method patch (0.01s)
✔ MethodConditionCest: Create a specification that checks url using matches (0.01s)
✔ ProxyCest: Create an expectation with proxy to test (0.01s)
✔ ProxyCest: Proxy to given uri test (0.64s)
✔ ReplacementCest: Create an expectation with regex replacement from url (0.02s)
✔ ReplacementCest: Create an expectation with regex replacement from body (0.02s)
✔ ReplacementCest: Create an expectation with regex replacement from body and url (0.02s)
✔ ReplacementCest: Create an expectation with strict regex replacement from body and url (0.01s)
✔ ReplacementCest: Create an expectation without regex replacement (0.01s)
✔ StatusCodeSpecificationCest: Create a specification with a valid status code (0.01s)
✔ StatusCodeSpecificationCest: Create a specification with a default status code (0.01s)
✔ StatusCodeSpecificationCest: Fail when the status code is not set (0.01s)
✔ UrlConditionCest: Create an expectation that checks url using isequalto (0.01s)
✔ UrlConditionCest: Create an expectation that checks url using matches (0.01s)
✔ UrlConditionCest:  check if it fails when an invalid matcher is specified (0.01s)
✔ UrlConditionCest: Check if it fails when an invalid value is specified (0.01s)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Functional Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Unit Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Time: 13.21 seconds, Memory: 16.00MB

OK (68 tests, 248 assertions)
```
I've used the same code as in `src/bin/phiremock.php` with directory depth offset.