### PR TITLE
Have ability to search made request by condition

### DIFF
--- a/src/Client/Phiremock.php
+++ b/src/Client/Phiremock.php
@@ -131,6 +131,34 @@ class Phiremock
     }
 
     /**
+     * List requests was executed in phiremock.
+     *
+     * @param \Mcustiel\Phiremock\Client\Utils\RequestBuilder $requestBuilder
+     *
+     * @return array
+     */
+    public function listExecutions(RequestBuilder $requestBuilder)
+    {
+        $expectation = $requestBuilder->build();
+        $expectation->setResponse(new Response());
+        $uri = $this->createBaseUri()->withPath(self::API_EXECUTIONS_URL);
+
+        $request = (new PsrRequest())
+            ->withUri($uri)
+            ->withMethod('put')
+            ->withHeader('Content-Type', 'application/json')
+            ->withBody(new StringStream(json_encode($expectation)));
+
+        $response = $this->connection->send($request);
+
+        if ($response->getStatusCode() === 200) {
+            return json_decode($response->getBody()->__toString());
+        }
+
+        $this->checkErrorResponse($response);
+    }
+
+    /**
      * Resets all the scenarios to start state.
      */
     public function resetScenarios()

--- a/src/Server/Actions/ListRequestsAction.php
+++ b/src/Server/Actions/ListRequestsAction.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Mcustiel\Phiremock\Server\Actions;
+
+use Mcustiel\Phiremock\Common\StringStream;
+use Mcustiel\Phiremock\Domain\Expectation;
+use Mcustiel\Phiremock\Server\Actions\Base\AbstractRequestAction;
+use Mcustiel\Phiremock\Server\Model\RequestStorage;
+use Mcustiel\Phiremock\Server\Utils\RequestExpectationComparator;
+use Mcustiel\PowerRoute\Actions\ActionInterface;
+use Mcustiel\PowerRoute\Common\TransactionData;
+use Mcustiel\SimpleRequest\RequestBuilder;
+use Psr\Log\LoggerInterface;
+
+class ListRequestsAction extends AbstractRequestAction implements ActionInterface
+{
+    /**
+     * @var \Mcustiel\Phiremock\Server\Model\RequestStorage
+     */
+    private $requestsStorage;
+    /**
+     * @var \Mcustiel\Phiremock\Server\Utils\RequestExpectationComparator
+     */
+    private $comparator;
+
+    public function __construct(
+        RequestBuilder $requestBuilder,
+        RequestStorage $storage,
+        RequestExpectationComparator $comparator,
+        LoggerInterface $logger
+    ) {
+        parent::__construct($requestBuilder, $logger);
+        $this->requestsStorage = $storage;
+        $this->comparator = $comparator;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Mcustiel\PowerRoute\Actions\ActionInterface::execute()
+     */
+    public function execute(TransactionData $transactionData, $argument = null)
+    {
+        $transactionData->setResponse(
+            $this->processAndGetResponse(
+                $transactionData,
+                function (TransactionData $transaction, Expectation $expectation) {
+                    $this->validateRequestOrThrowException($expectation, $this->logger);
+                    $executions = $this->searchForExecutionsCount($expectation);
+                    $this->logger->debug('Listed ' . count($executions) . ' request matching the expectation');
+
+                    return $transaction->getResponse()
+                        ->withStatus(200)
+                        ->withHeader('Content-Type', 'application/json')
+                        ->withBody(new StringStream(json_encode($executions)));
+                }
+            )
+        );
+    }
+
+    private function searchForExecutionsCount(Expectation $expectation)
+    {
+        $executions = [];
+        foreach ($this->requestsStorage->listRequests() as $request) {
+            if ($this->comparator->equals($request, $expectation)) {
+                $executions[] = [
+                    'method' => $request->getMethod(),
+                    'url' => (string) $request->getUri(),
+                    'headers' => $request->getHeaders(),
+                    'cookies' => $request->getCookieParams(),
+                    'body' => (string) $request->getBody(),
+                ];
+            }
+        }
+
+        return $executions;
+    }
+}

--- a/src/Server/Config/dependencies-setup.php
+++ b/src/Server/Config/dependencies-setup.php
@@ -9,6 +9,7 @@ use Mcustiel\Phiremock\Server\Actions\AddExpectationAction;
 use Mcustiel\Phiremock\Server\Actions\ClearExpectationsAction;
 use Mcustiel\Phiremock\Server\Actions\ClearScenariosAction;
 use Mcustiel\Phiremock\Server\Actions\CountRequestsAction;
+use Mcustiel\Phiremock\Server\Actions\ListRequestsAction;
 use Mcustiel\Phiremock\Server\Actions\ListExpectationsAction;
 use Mcustiel\Phiremock\Server\Actions\ResetRequestsCountAction;
 use Mcustiel\Phiremock\Server\Actions\SearchRequestAction;
@@ -203,6 +204,15 @@ $di->register('actionFactory', function () use ($di) {
         ),
         'countRequests' => new SingletonLazyCreator(
             CountRequestsAction::class,
+            [
+                $di->get('requestBuilder'),
+                $di->get('requestStorage'),
+                $di->get('requestExpectationComparator'),
+                $di->get('logger'),
+            ]
+        ),
+        'listRequests' => new SingletonLazyCreator(
+            ListRequestsAction::class,
             [
                 $di->get('requestBuilder'),
                 $di->get('requestStorage'),

--- a/src/Server/Config/router-config.php
+++ b/src/Server/Config/router-config.php
@@ -163,6 +163,28 @@ return [
                     ['countRequests' => null],
                 ],
                 'else' => [
+                    ['goto' => 'verifyMethodIsPut'],
+                ],
+            ],
+        ],
+        'verifyMethodIsPut' => [
+            'condition' => [
+                'all-of' => [
+                    [
+                        'input-source' => ['method' => null],
+                        'matcher'      => ['isEqualTo' => 'PUT'],
+                    ],
+                    [
+                        'input-source' => ['header' => 'Content-Type'],
+                        'matcher'      => ['isEqualTo' => 'application/json'],
+                    ],
+                ],
+            ],
+            'actions' => [
+                'if-matches' => [
+                    ['listRequests' => null],
+                ],
+                'else' => [
                     ['goto' => 'verifyMethodIsDelete'],
                 ],
             ],

--- a/tests/tests/acceptance/ClientCest.php
+++ b/tests/tests/acceptance/ClientCest.php
@@ -158,6 +158,36 @@ class ClientCest
         $I->assertEquals(2, $count);
     }
 
+    public function listExecutionsTest(AcceptanceTester $I)
+    {
+        $I->sendDELETE('/__phiremock/executions');
+        $expectation = new Expectation();
+        $request = new Request();
+        $request->setMethod('get');
+        $request->setUrl(Is::matching('~^/(potato|tomato)~'));
+        $response = new Response();
+        $response->setStatusCode(201);
+        $response->setBody('Tomato!');
+        $expectation->setRequest($request)->setResponse($response);
+        $this->phiremock->createExpectation($expectation);
+
+        $I->sendGET('/potato');
+        $I->seeResponseCodeIs(201);
+        $I->seeResponseEquals('Tomato!');
+
+        $I->sendGET('/potato');
+        $I->sendGET('/tomato');
+
+        $executions = $this->phiremock->listExecutions(
+            A::getRequest()->andUrl(Is::equalTo('/potato'))
+        );
+        $I->assertEquals(2, count($executions));
+        foreach ($executions as $item) {
+            $I->assertEquals('GET', $item->method);
+            $I->assertContains('potato', $item->url);
+        }
+    }
+
     public function countExecutionsWhenNoExpectationIsSet(AcceptanceTester $I)
     {
         $I->sendDELETE('/__phiremock/executions');


### PR DESCRIPTION
Issue link: https://github.com/mcustiel/phiremock/issues/23

Tests result:
```
$ vendor/bin/codecept -c tests run
Codeception PHP Testing Framework v2.3.5
Powered by PHPUnit 6.2.4 by Sebastian Bergmann and contributors.
Running exec php /opt/phiremock/tests/tests/../../bin/phiremock --port 8086

Acceptance Tests (69) -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
✔ BodyConditionCest: Create an expectation that checks body using isequalto (0.24s)
✔ BodyConditionCest: Create an expectation that checks body using matches (0.02s)
✔ BodyConditionCest: See if request fails when an invalid matcher is specified (0.02s)
✔ BodyConditionCest: Check if the request fails when and invalid value is specified (0.01s)
✔ BodyConditionCest: See if mocking based in request body pattern works (0.01s)
✔ BodyConditionCest: See if mocking based in request body equality works (0.01s)
✔ BodyConditionCest: See if mocking based in request body case insensitive equality works (0.01s)
✔ BodyJsonCest: Create an expectation with a json body defined as array (0.01s)
✔ BodyJsonCest: Create an expectation with a json body defined as object (0.01s)
✔ BodySpecificationCest: Create an expectation with a valid body (0.01s)
✔ BodySpecificationCest: Create an expectation with an empty body (0.01s)
✔ ClientCest: Should create an expectation test (0.02s)
✔ ClientCest: Should create an expectation and receive it in the list (0.02s)
✔ ClientCest: Should list several expectations (0.02s)
✔ ClientCest: Should create an expectation test with fluent interface (3.52s)
✔ ClientCest: Count executions test (0.03s)
✔ ClientCest: List executions test (0.03s)
✔ ClientCest: Count executions when no expectation is set (0.06s)
✔ ClientCest: Contains matcher should work (2.51s)
✔ ClientCest: Full url should be evaluated (2.52s)
✔ DelaySpecificationCest: Create an expectation with a valid delay specification (0.02s)
✔ DelaySpecificationCest: Create an expectation with a negative delay specification (0.04s)
✔ DelaySpecificationCest: Create an expectation with an invalid delay specification (0.01s)
✔ DelaySpecificationCest: Mock a request with delay (2.01s)
✔ ExpectationCreationCest: Create an expectation that only checks url (0.02s)
✔ ExpectationCreationCest: Create an expectation that only checks method (0.02s)
✔ ExpectationCreationCest: Create an expectation that only checks body (0.01s)
✔ ExpectationCreationCest: Create an expectation that only checks headers (0.01s)
✔ ExpectationCreationCest: See if creation fails when request is empty (0.01s)
✔ ExpectationCreationCest: When response is empty in request, default should be used (0.01s)
✔ ExpectationCreationCest: See if creation fails when anything sent as request (0.01s)
✔ ExpectationCreationCest: See if creation fails when anything sent as response (0.01s)
✔ ExpectationCreationCest: Create an expectation with all possible option filled (0.01s)
✔ ExpectationListCest: Return empty list test (0.00s)
✔ ExpectationListCest: Return created expectation test (0.01s)
✔ HeadersConditionsCest: Create an expectation that checks one header using isequalto (0.01s)
✔ HeadersConditionsCest: Create an expectation that checks one header using matches (0.01s)
✔ HeadersConditionsCest: Fail when the matcher is invalid (0.01s)
✔ HeadersConditionsCest: Fail when the value is null (0.01s)
✔ HeadersConditionsCest: Create an expectation that checks more than one header (0.01s)
✔ HeadersConditionsCest: See if mocking based in one request header works (0.01s)
✔ HeadersConditionsCest: See if mocking based in several request headers works (0.01s)
✔ HeadersSpecificationCest: Create an specification with one header in response (0.01s)
✔ HeadersSpecificationCest: Create an specification with several headers in response (0.01s)
✔ HeadersSpecificationCest: Create a specification with no headers in response (0.01s)
✔ HeadersSpecificationCest: Fail when creating a specification with invalid headers (0.01s)
✔ MethodConditionCest: Create a specification with method post (0.01s)
✔ MethodConditionCest: Create a specification with method get (0.01s)
✔ MethodConditionCest: Create a specification with method put (0.01s)
✔ MethodConditionCest: Create a specification with method delete (0.01s)
✔ MethodConditionCest: Create a specification with method fetch (0.01s)
✔ MethodConditionCest: Create a specification with method options (0.01s)
✔ MethodConditionCest: Create a specification with method head (0.01s)
✔ MethodConditionCest: Create a specification with method patch (0.01s)
✔ MethodConditionCest: Create a specification that checks url using matches (0.01s)
✔ ProxyCest: Create an expectation with proxy to test (0.01s)
✔ ProxyCest: Proxy to given uri test (0.73s)
✔ ReplacementCest: Create an expectation with regex replacement from url (0.02s)
✔ ReplacementCest: Create an expectation with regex replacement from body (0.01s)
✔ ReplacementCest: Create an expectation with regex replacement from body and url (0.01s)
✔ ReplacementCest: Create an expectation with strict regex replacement from body and url (0.01s)
✔ ReplacementCest: Create an expectation without regex replacement (0.01s)
✔ StatusCodeSpecificationCest: Create a specification with a valid status code (0.01s)
✔ StatusCodeSpecificationCest: Create a specification with a default status code (0.01s)
✔ StatusCodeSpecificationCest: Fail when the status code is not set (0.01s)
✔ UrlConditionCest: Create an expectation that checks url using isequalto (0.01s)
✔ UrlConditionCest: Create an expectation that checks url using matches (0.01s)
✔ UrlConditionCest:  check if it fails when an invalid matcher is specified (0.01s)
✔ UrlConditionCest: Check if it fails when an invalid value is specified (0.01s)
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Functional Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Unit Tests (0) ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Time: 14.2 seconds, Memory: 16.00MB

OK (69 tests, 255 assertions)
```