### PR TITLE
Fix request headers in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ Then, using phiremock's REST interface, expectations can be configured, specifyi
             "matches" : "/some regex pattern/i"
         },
         "headers" : {
-            "X-MY-HEADER": "Some value"
+            "X-MY-HEADER": {
+                "contains" : "Some value"
+            }
         }
     },
     "response": {


### PR DESCRIPTION
There is a problem in documentation about headers. 