### PR TITLE
Support regex replacements in headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,9 @@ using `${body.matchIndex}` or `${url.matchIndex}` notation.
             ->andBody(Is::matching('~\{"name" : "([^"]+)"\}~'))
             ->andHeader('Content-Type', Is::equalTo('application/json'))
     )->then(
-        Respond::withStatusCode(200)->andBody('The resource is ${url.1}, the id is ${url.2} and the name is ${body.1}')
+        Respond::withStatusCode(200)
+            ->andBody('The resource is ${url.1}, the id is ${url.2} and the name is ${body.1}')
+            ->andHeader('X-id', 'id is ${url.2}')
     );
     $phiremock->createExpectation($expectation);
 ```


### PR DESCRIPTION
I have a scenario in which I want to use Phiremock to mock a redirect / return cycle in which a state parameter on the URL needs to be returned as part of the Location header of the mocked response. It seems reasonable to support the regex replacements in any header of the Response, the same for the body.

Example of the mocking:
```
$I->expectARequestToRemoteServiceWithAResponse(
    Phiremock::on(
        A::getRequest()->andUrl(Is::matching('~\/oauth2\?state=(.+)~'));
    )->then(
        Respond::withStatusCode(302)->andHeader('Location', 'https://example.com/callback?state=${url.1}')
    )
);
```

Tests:
```
root@65168152b6d7:/var/www# ./vendor/bin/codecept run acceptance -c tests -- tests/tests/acceptance/ReplacementCest.php
Codeception PHP Testing Framework v2.5.6
Powered by PHPUnit 7.5.18 by Sebastian Bergmann and contributors.
Running with seed:

Running php /var/www/tests/tests/../../bin/phiremock --port 8086 -d -e /var/www/tests/tests/acceptance/../_data/expectations > /var/www/tests/tests/_output//phiremock.log 2>&1

Acceptance Tests (19) --------------------------------------------------------------------------------------------------------------------------------------------------------------
✔ ReplacementCest: Create an expectation with regex replacement from url (0.50s)
✔ ReplacementCest: Create an expectation with regex from url as group expression (0.01s)
✔ ReplacementCest: Create an expectation with regex replacement from body (0.02s)
✔ ReplacementCest: Create an expectation with regex from body as group expression (0.01s)
✔ ReplacementCest: Create an expectation with regex replacement from body and url (0.01s)
✔ ReplacementCest: Create an expectation with regex from body and url as group expression (0.02s)
✔ ReplacementCest: Create an expectation with strict regex replacement from body and url (0.01s)
✔ ReplacementCest: Create an expectation with strict regex from body and url as group expression (0.01s)
✔ ReplacementCest: Create an expectation without regex replacement (0.02s)
✔ ReplacementCest: Create an expectation with regex match groups from url (0.01s)
✔ ReplacementCest: Create an expectation with regex match groups from body (0.02s)
✔ ReplacementCest: Create an expectation with regex match groups from body and url (0.01s)
✔ ReplacementCest: Create an expectation with regex multiple match groups from body (0.01s)
✔ ReplacementCest: Create an expectation without regex match groups (0.01s)
✔ ReplacementCest: Create an expectation with regex replacement in header from url (0.01s)
✔ ReplacementCest: Create an expectation with regex replacement in header from body (0.01s)
✔ ReplacementCest: Create an expectation with regex replacement in header from body and url (0.00s)
✔ ReplacementCest: Create an expectation with regex replacement in header as group expression (0.01s)
✔ ReplacementCest: Create an expectation with regex replacement in header with multiple match groups (0.01s)
------------------------------------------------------------------------------------------------------------
```